### PR TITLE
Add dynamic MNIST demo using continuous backprop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Agent Instructions
+
+## Environment Setup
+- Python 3.12 with CPU-only PyTorch 2.8.0 and torchvision 0.23.0 are installed via `pip install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu`.
+- Additional dependencies: `tqdm`, `PyYAML`, `scipy`, `mlproj-manager`, `zipp`, `pycparser`, `gym`, and friends were installed with `pip`.
+- The repository can be used without installation, but running `pip install -e .` exposes the `lop` package globally.
+
+## Working with Scripts
+- Scripts run modules from the `lop` package. When adding new scripts, append the repository root to `sys.path` so they work without installing the package.
+- Example training script: `python scripts/dynamic_mnist_cbp.py` trains a tiny conv+linear network on a MNIST stream where class proportions perform a random walk. Pass `--cbp` to enable Continuous Backprop layers or omit it for a vanilla baseline.
+- The MNIST dataset is downloaded automatically under `data/`, which is git-ignored.
+
+## Checks
+- After modifying training logic or CBP layers, run `python scripts/dynamic_mnist_cbp.py --epochs 1` (and optionally `--cbp`) to ensure the model still trains and reports reasonable accuracy.

--- a/scripts/dynamic_mnist_cbp.py
+++ b/scripts/dynamic_mnist_cbp.py
@@ -1,0 +1,151 @@
+"""Train a tiny ConvNet on a class-skewed MNIST stream with optional CBP layers.
+
+Instead of permuting pixels, this variant drifts the *class distribution* over
+time. Each digit maintains a sampling weight that performs a small random walk
+between 0.01 and 1.0. For every training example we first perturb all weights,
+then draw a class in proportion to those weights and sample an image of that
+class. The result is a continually changing, nonstationary stream where some
+digits become temporarily rare while others dominate.
+
+Vanilla networks tend to over-specialize toward classes that appear early in
+training. When Continuous Backprop (``--cbp``) is enabled, filters can be
+replaced over time, helping the model adapt as the class proportions drift and
+yielding more stable accuracy under this shift.
+"""
+
+import argparse
+import os
+import sys
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from torch.utils.data import DataLoader
+from torchvision import datasets, transforms
+
+# Allow running the script directly without installing the package.
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from lop.algos.cbp_conv import CBPConv
+from lop.algos.cbp_linear import CBPLinear
+
+
+class SimpleNet(nn.Module):
+    """Minimal network with one convolutional and one linear layer.
+
+    When ``use_cbp`` is True, CBPConv/CBPLinear wrappers are inserted to enable
+    continual feature replacement; otherwise the plain layers are used.
+    """
+
+    def __init__(self, use_cbp: bool):
+        super().__init__()
+        # Convolutional feature extractor
+        self.conv = nn.Conv2d(1, 16, kernel_size=5)
+        self.pool = nn.MaxPool2d(2, 2)
+        # After conv (28->24) and pooling (24->12)
+        self.fc1 = nn.Linear(16 * 12 * 12, 32)
+        self.fc2 = nn.Linear(32, 10)
+        self.act = nn.ReLU()
+
+        if use_cbp:
+            self.cbp_conv = CBPConv(
+                in_layer=self.conv,
+                out_layer=self.fc1,
+                num_last_filter_outputs=12 * 12,
+                replacement_rate=1e-4,
+                maturity_threshold=100,
+            )
+            self.cbp_fc = CBPLinear(
+                in_layer=self.fc1,
+                out_layer=self.fc2,
+                replacement_rate=1e-4,
+                maturity_threshold=100,
+            )
+        else:
+            self.cbp_conv = None
+            self.cbp_fc = None
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.pool(self.act(self.conv(x)))
+        if self.cbp_conv is not None:
+            x = self.cbp_conv(x)
+        x = x.view(x.size(0), -1)
+        x = self.act(self.fc1(x))
+        if self.cbp_fc is not None:
+            x = self.cbp_fc(x)
+        x = self.fc2(x)
+        return x
+
+
+def get_data(batch_size: int = 64):
+    """Return the MNIST train dataset and a test loader."""
+    transform = transforms.ToTensor()
+    train = datasets.MNIST(root="data", train=True, download=True, transform=transform)
+    test = datasets.MNIST(root="data", train=False, download=True, transform=transform)
+    test_loader = DataLoader(test, batch_size=batch_size)
+    return train, test_loader
+
+
+def evaluate(model: nn.Module, loader: DataLoader, device: torch.device) -> float:
+    """Compute classification accuracy on binarized MNIST images."""
+    model.eval()
+    correct = 0
+    total = 0
+    with torch.no_grad():
+        for x, y in loader:
+            x = torch.bernoulli(x)  # binarize at evaluation time
+            x, y = x.to(device), y.to(device)
+            preds = model(x)
+            correct += (preds.argmax(dim=1) == y).sum().item()
+            total += y.size(0)
+    model.train()
+    return correct / total
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cbp", action="store_true", help="Enable CBP layers")
+    parser.add_argument("--epochs", type=int, default=10, help="Number of training epochs")
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    batch_size = 64
+    train_set, test_loader = get_data(batch_size)
+    model = SimpleNet(use_cbp=args.cbp).to(device)
+    opt = optim.SGD(model.parameters(), lr=0.1)
+    criterion = nn.CrossEntropyLoss()
+    # Pre-compute indices for each class to allow sampling with replacement.
+    class_indices = [torch.where(train_set.targets == i)[0] for i in range(10)]
+    weights = torch.ones(10)
+
+    def drift_weights(w: torch.Tensor, step: float = 0.01) -> torch.Tensor:
+        """Perform a small random walk and clamp the weights to [0.01, 1]."""
+        w += torch.randn_like(w) * step
+        return w.clamp_(0.01, 1.0)
+
+    steps_per_epoch = len(train_set) // batch_size  # roughly one pass worth of samples
+
+    for epoch in range(1, args.epochs + 1):
+        for _ in range(steps_per_epoch):
+            batch_x, batch_y = [], []
+            for _ in range(batch_size):
+                weights = drift_weights(weights)
+                probs = weights / weights.sum()
+                c = torch.multinomial(probs, 1).item()
+                idx = class_indices[c][torch.randint(len(class_indices[c]), (1,))]
+                x, y = train_set[idx.item()]
+                batch_x.append(torch.bernoulli(x))
+                batch_y.append(y)
+
+            x = torch.stack(batch_x).to(device)
+            y = torch.tensor(batch_y, device=device)
+            opt.zero_grad()
+            loss = criterion(model(x), y)
+            loss.backward()
+            opt.step()
+
+        acc = evaluate(model, test_loader, device)
+        print(f"Epoch {epoch}: test accuracy {acc:.3f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- simulate nonstationary MNIST by random-walking per-class sampling weights, replacing the pixel permutation drift
- document how class proportions change over time and why CBP helps adapt to this shift
- update contributor instructions to mention the new class-skewed training stream

## Testing
- `python scripts/dynamic_mnist_cbp.py --epochs 1`
- `python scripts/dynamic_mnist_cbp.py --cbp --epochs 1`


------
https://chatgpt.com/codex/tasks/task_e_68b0282b31f88326ac1984f73b724335